### PR TITLE
Auto-detect vendor logo from board info

### DIFF
--- a/crates/riscfetch-cli/src/main.rs
+++ b/crates/riscfetch-cli/src/main.rs
@@ -26,8 +26,20 @@ fn main() {
         return;
     }
 
+    // Auto-detect vendor logo when not explicitly specified
+    let logo = if args.logo == "default" {
+        let board_info = info::get_board_info();
+        let compatible = std::fs::read_to_string("/proc/device-tree/compatible")
+            .unwrap_or_default();
+        vendors::detect_vendor(&board_info, &compatible)
+            .unwrap_or("default")
+            .to_string()
+    } else {
+        args.logo.clone()
+    };
+
     display_riscv_info(
-        &args.logo,
+        &logo,
         &args.style,
         args.explain,
         args.riscv_only,


### PR DESCRIPTION
## Summary

- When `--logo` is not specified, auto-detect the vendor from `/proc/device-tree/model` and `/proc/device-tree/compatible`
- Match against 27 keywords covering all 13 supported vendors (board names, SoC names, vendor names)
- Explicit `--logo <vendor>` still takes priority

Closes #1

## Test plan

- [x] Unit tests for `detect_vendor()` with known board strings (model, compatible, case-insensitive, unknown)
- [x] All 71 existing tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)