### PR TITLE
fix: Orange Pi RV2 (SpacemiT K1) を SpacemiT として検出 (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Detect Orange Pi RV2 (SpacemiT K1) as SpacemiT vendor. Ky-derived kernels expose `ky,x1` / `ky,orangepi-rv2` in `/proc/device-tree/compatible` instead of `spacemit,*`, so the existing `spacemit` keyword missed them and the board fell back to the generic RISC-V logo.
+
 ## [2.3.0] - 2026-04-06
 
 ### Added

--- a/crates/riscfetch-cli/src/vendors.rs
+++ b/crates/riscfetch-cli/src/vendors.rs
@@ -92,6 +92,7 @@ const VENDOR_KEYWORDS: &[(&str, &str)] = &[
     ("cv1800", "sophgo"),
     ("sg2000", "sophgo"),
     ("ch32v", "wch"),
+    ("ky,x1", "spacemit"),
     // Vendor names (generic, checked after specific keywords)
     ("eswin", "eswin"),
     ("ultrarisc", "ultrarisc"),
@@ -240,6 +241,14 @@ mod tests {
     #[test]
     fn test_detect_vendor_unknown_board() {
         assert_eq!(detect_vendor("Some Unknown Board", "unknown,board"), None);
+    }
+
+    #[test]
+    fn test_detect_orangepi_rv2_as_spacemit() {
+        assert_eq!(
+            detect_vendor("ky x1 orangepi-rv2 board", "ky,orangepi-rv2 ky,x1"),
+            Some("spacemit")
+        );
     }
 
     #[test]

--- a/crates/riscfetch-cli/src/vendors.rs
+++ b/crates/riscfetch-cli/src/vendors.rs
@@ -252,6 +252,14 @@ mod tests {
     }
 
     #[test]
+    fn test_ky_orangepi_alone_does_not_match() {
+        // We deliberately key on "ky,x1" only. A bare "ky,orangepi-rv2" without
+        // "ky,x1" is rejected so future Ky-derived boards on non-SpacemiT SoCs
+        // are not silently miscategorized.
+        assert_eq!(detect_vendor("", "ky,orangepi-rv2"), None);
+    }
+
+    #[test]
     fn test_all_vendors_have_info() {
         for (aliases, display_name, subtitle) in VENDORS {
             assert!(!aliases.is_empty(), "Vendor must have at least one alias");


### PR DESCRIPTION
## 関連 Issue
closes #11

## 変更内容

`VENDOR_KEYWORDS` に `("ky,x1", "spacemit")` を追加し、Orange Pi RV2 などの Ky 派生カーネルが吐く device-tree 文字列を SpacemiT として検出できるようにした。

### 背景

Orange Pi RV2 のカーネル (Ky 派生) は `/proc/device-tree/compatible` に `ky,orangepi-rv2` `ky,x1` を、`/proc/device-tree/model` に `ky x1 orangepi-rv2 board` を吐く。`spacemit,*` 文字列がどこにも出ないため、既存の `"spacemit"` キーワードでヒットせず汎用 RISC-V ロゴへフォールバックしていた。

### 採用しなかった案

- `"ky,"` のような広いマッチ — Ky は SoC ベンダーではなく Orange Pi 向けディストロ／DTB 派生。将来 Ky が別社 SoC を採用した場合の silent miscategorization を避けたい
- `"orangepi-rv2"` — board 文字列にしか出ない冗長キーワード
- "Ky" を独立ベンダーとして登録 — distro 単位での増殖を避けるため、既存方針 (mango = Allwinner ロゴ) と一貫させた

### 影響範囲

Banana Pi BPI-F3 など、`spacemit,k1` を吐く本流カーネルのボードは既存 `"spacemit"` キーワードでヒット済みのため影響なし。本 PR は Ky 派生 DTB を使うボードのみが対象。

## テスト

- `test_detect_orangepi_rv2_as_spacemit` を追加 (実機 `/proc/device-tree/*` 文字列を入力)
- `cargo test`: 全 46 件パス
- `cargo clippy --all-targets -- -D warnings`: 警告なし

## 実機検証

修正後 pi-rv2 にバイナリをコピーして `riscfetch` を実行すると、汎用 "RISC-V" ロゴから "SpacemiT" / "RISC-V by SpacemiT" に変わる想定。